### PR TITLE
Acknowledge on failure response from server.

### DIFF
--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -180,6 +180,12 @@ defmodule Query.Test do
     refute r.plan == nil
     assert List.first(r.plan["children"])["operatorType"] == "CartesianProduct"
   end
+
+  test "can execute a query after a failure", context do
+    conn = context[:conn]
+    assert {:error, _} = Bolt.Sips.query(conn, "INVALID CYPHER")
+    assert {:ok, [%{"n" => 22}]} = Bolt.Sips.query(conn, "RETURN 22 as n")
+  end
 end
 
 


### PR DESCRIPTION
Hi,

When an invalid statement is sent to the server, we get a `{:failure, reason}` result. However upon receiving these failure responses, the client is supposed to send an `ack_failure` signal back to the server. Otherwise for all future queries the response seems just to be `{:ignored, _}`

Boltex does [define `@sig_ack_failure`](https://github.com/mschae/boltex/blob/master/lib/boltex/bolt.ex#L15) but it seems to never be used on it's code. I've submitted another PR mschae/boltex#10 for adding a `Boltex.Bolt.ack_failure` function to Boltex as that seems the right place for it.

Any feedback @florinpatrascu @mschae ?