### PR TITLE
Let Bolt.Sips.Response transform values of literal objects.

### DIFF
--- a/lib/bolt_sips/response.ex
+++ b/lib/bolt_sips/response.ex
@@ -125,6 +125,10 @@ defmodule Bolt.Sips.Response do
     struct(UnboundRelationship, rel)
   end
 
+  defp extract_types(map) when is_map(map) do
+    for {k, v} <- map, do: {k, extract_types(v)}, into: %{}
+  end
+
   defp extract_types(r), do: extract_any(r, [])
 
   defp extract_any([], acc), do: Enum.reverse(acc)

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -185,6 +185,15 @@ defmodule Query.Test do
     assert {:error, _} = Bolt.Sips.query(conn, "INVALID CYPHER")
     assert {:ok, [%{"n" => 22}]} = Bolt.Sips.query(conn, "RETURN 22 as n")
   end
-end
 
+  test "values from an object literal get transformed to their type", context do
+    conn = context[:conn]
+    obj = Bolt.Sips.query!(conn, "MATCH (d:Deamon) RETURN {x: count(d), y: d} as obj")
+    |> List.first
+    |> Map.get("obj")
+    assert obj["x"] == 1
+    assert obj["y"].labels == ["Deamon"]
+    assert obj["y"].properties["name"] == "Chandrian"
+  end
+end
 


### PR DESCRIPTION
When a literal object is returned from a query and one of its
values is say a node or relationship, they should be transformed
into their corresponding Bolt.Sips.Type.