### PR TITLE
Bolt struct handler for pack encoder

### DIFF
--- a/lib/boltex/pack_stream/encoder.ex
+++ b/lib/boltex/pack_stream/encoder.ex
@@ -1,4 +1,5 @@
 defprotocol Boltex.PackStream.Encoder do
+  @fallback_to_any true
   @doc "Encodes an item to its binary PackStream Representation"
   def encode(entitiy)
 end
@@ -116,9 +117,9 @@ defimpl Boltex.PackStream.Encoder, for: Map do
 end
 
 defimpl Boltex.PackStream.Encoder, for: Any do
-  def encode(item) if is_map(item) do
+  def encode(item) when is_map(item) do
     item
     |> Map.from_struct
-    |> Bolter.PackStream.Encoder.encode 
+    |> Boltex.PackStream.Encoder.encode
   end
 end

--- a/lib/boltex/pack_stream/encoder.ex
+++ b/lib/boltex/pack_stream/encoder.ex
@@ -114,3 +114,11 @@ defimpl Boltex.PackStream.Encoder, for: Map do
     Boltex.PackStream.Encoder.encode(value)
   end
 end
+
+defimpl Boltex.PackStream.Encoder, for: Any do
+  def encode(item) if is_map(item) do
+    item
+    |> Map.from_struct
+    |> Bolter.PackStream.Encoder.encode 
+  end
+end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -1,5 +1,10 @@
 defmodule Query.Test do
   use ExUnit.Case, async: true
+  alias Query.Test
+
+  defmodule TestUser do
+    defstruct name: "", bolt_sips: true
+  end
 
   setup_all do
     # reuse the same connection for all the tests in the suite
@@ -61,6 +66,26 @@ defmodule Query.Test do
         assert List.first(rows)["name"] == "Kote", "expecting to find Kote"
       {:error, reason} -> IO.puts "Error: #{reason["message"]}"
     end
+  end
+
+  test "executing a Cpyher query, with struct parameters", context do
+    conn = context[:conn]
+
+    cypher = """
+      CREATE(n:Person {props})
+    """
+
+    assert {:ok, _} = Bolt.Sips.query(conn, cypher, %{props: %Test.TestUser{name: "Strut"}})
+  end
+
+  test "executing a Cpyher query, with map parameters", context do
+    conn = context[:conn]
+
+    cypher = """
+      CREATE(n:Person {props})
+    """
+
+    assert {:ok, _} = Bolt.Sips.query(conn, cypher, %{props: %{name: "Mep"}})
   end
 
   test "executing a raw Cypher query with alias, and no parameters", context do
@@ -209,5 +234,3 @@ defmodule Query.Test do
     assert {:ok, [%{"n" => 22}]} = Bolt.Sips.query(conn, "RETURN 22 as n")
   end
 end
-
-

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -72,7 +72,7 @@ defmodule Query.Test do
     conn = context[:conn]
 
     cypher = """
-      CREATE(n:Person {props})
+      CREATE(n:User {props})
     """
 
     assert {:ok, _} = Bolt.Sips.query(conn, cypher, %{props: %Test.TestUser{name: "Strut"}})
@@ -82,7 +82,7 @@ defmodule Query.Test do
     conn = context[:conn]
 
     cypher = """
-      CREATE(n:Person {props})
+      CREATE(n:User {props})
     """
 
     assert {:ok, _} = Bolt.Sips.query(conn, cypher, %{props: %{name: "Mep"}})


### PR DESCRIPTION
    BOLT: Struct Handler for PackEncoder

    - Add a `@fallback_to_any` directive for `Boltex.PackStream.Encoder`
      for falling back to `Any` implementation
    - Add a new implementation for `Any`
      * Specifically, when the passed structure is a struct, it will
        fall into the category since `is_map/1` guard clause will work
      * It transform the `struct` to `map` and then calling
        `Boltex.PackStream.Encoder.encode/1`, which will invoke the
        implementation for the `Map` encoder
    - Add two test cases in `query_test.exs` to test the code handles
      `Map` and `Struct` correctly