### PR TITLE
Bring up `:boltex` and `:retry` in `applications`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule BoltSips.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :poolboy, :con_cache] ++ opt_etls(),
+    [applications: [:logger, :poolboy, :con_cache, :retry, :boltex] ++ opt_etls(),
      mod: {Bolt.Sips.Application, []}]
   end
 


### PR DESCRIPTION
I've noticed that `boltex` and `retry` are listed as dependencies but their apps are not started properly. For users using `elixir` under `1.4.0`, the applications won't start themselves automatically causing failures in productions environment. This patch explicitly start those apps. 

Let me know how you think about this one. Thanks for your time and looking forward to hear from you!