### PR TITLE
add the fuzzyurl to the list of apps

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule BoltSips.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :poolboy, :con_cache, :retry, :boltex] ++ opt_etls(),
+    [applications: [:logger, :poolboy, :con_cache, :retry, :boltex, :fuzzyurl] ++ opt_etls(),
      mod: {Bolt.Sips.Application, []}]
   end
 


### PR DESCRIPTION
The fuzzyurl must be placed there, otherwise, when the url config option is in use, the following error appears in a compiled project:

```
(UndefinedFunctionError) function Fuzzyurl.from_string/1 is undefined (module Fuzzyurl is not available)
```

There is another option to fix the issue. A project using the bolt_sips has to add the fuzzyurl to its applications list. It [works](https://github.com/sirko-io/engine/blob/master/mix.exs#L22), but I think it is a wrong approach, the dependencies of the bolt_sips might be changed later.
