### PR TITLE
Keep Boltex version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule BoltSips.Mixfile do
       {:mix_test_watch, "~> 0.5.0", only: [:dev, :test]},
       {:benchee, "~> 0.10", only: :dev},
       # {:boltex, path: "../boltex/"},
-      {:boltex, "~> 0.3"},
+      {:boltex, "~> 0.3.0"},
       {:credo, "~> 0.8.8", only: [:dev, :test]}
     ] ++ env_specific_deps()
   end


### PR DESCRIPTION
Boltex `0.4.0` [has a non-backward update](https://github.com/mschae/boltex/blob/50123b8ed0e5a009908745f75e5e19084cfabd85/CHANGELOG.md#v040).
Accidentally updating (by `mix deps.update --all` etc.) causes connection init crash with a `WithClauseError`, and it loops forever trying to connect.
Until the `with` clause gets updated, Boltex version should be kept back I guess.