### PR TITLE
Bug fix: nanoseconds management in duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.2-rc2
+
+- Bug fix: Nanoseconds formating was erroneous. Example: 54 nanoseconds was formated to "PT0.54S" instead of "PT0.000000054S"
+- Bug fix: Large amount of nanoseconds (>= 1_000_000) wasn't treated and lead to Neo4j errors. Now large amount of nanosconds are converted in seconds, with the remainder in nanoseconds.
+
 ## 1.2.1-rc2
 
 - Bug fix: If a property contains a speciifc types (date, datetime, point, etc.), it wasn't decoded. see: https://github.com/florinpatrascu/bolt_sips/issues/55

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BoltSips.Mixfile do
   use Mix.Project
 
-  @version "1.2.1-rc2"
+  @version "1.2.2-rc2"
 
   def project do
     [

--- a/test/bolt_sips/types_test.exs
+++ b/test/bolt_sips/types_test.exs
@@ -69,7 +69,27 @@ defmodule Bolt.Sips.TypesTest do
     test "format_param/1 successful with valid data" do
       duration = Duration.create(15, 53, 125, 54)
 
-      assert {:ok, "P1Y3M53DT2M5.54S"} = Duration.format_param(duration)
+      assert {:ok, "P1Y3M53DT2M5.000000054S"} = Duration.format_param(duration)
+    end
+
+    test "format_param/1 successfull with large amount of nanoseconds (use create/4 to build struct)" do
+      duration = Duration.create(0, 0, 0, 12_545_876_654)
+      assert {:ok, "PT12.545876654S"} = Duration.format_param(duration)
+    end
+
+    test "format_param/1 successfull with large amount of nanoseconds (use %Duration{} to build struct)" do
+      duration = %Duration{
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        months: 0,
+        nanoseconds: 12_545_876_654,
+        seconds: 0,
+        weeks: 0,
+        years: 0
+      }
+
+      assert {:ok, "PT12.545876654S"} = Duration.format_param(duration)
     end
 
     test "format_param/1 fails for invalid data" do


### PR DESCRIPTION
For #57 
- Bug fix: Nanoseconds formating was erroneous. Example: 54 nanoseconds was formated to "PT0.54S" instead of "PT0.000000054S"
- Bug fix: Large amount of nanoseconds (>= 1_000_000) wasn't treated and lead to Neo4j errors. Now large amount of nanosconds are converted in seconds, with the remainder in nanoseconds.