### PR TITLE
Bug fix 73 perfromance

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Contributions and feedback, are very welcome. Thank you!
 
 ```elixir
 def deps do
-  [{:bolt_sips, "~> 2.0.0-rc}]
+  [{:bolt_sips, "~> 2.0.1-rc"}]
 end
 ```
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,8 +11,8 @@ level =
   end
 
 config :bolt_sips,
-  log: true,
-  log_hex: true
+  log: false,
+  log_hex: false
 
 config :logger, :console,
   level: level,

--- a/lib/bolt_sips/internals/pack_stream/decoder.ex
+++ b/lib/bolt_sips/internals/pack_stream/decoder.ex
@@ -60,9 +60,7 @@ defmodule Bolt.Sips.Internals.PackStream.Decoder do
   defp call_decode(data, original_version, used_version) do
     module = Module.concat(["Bolt.Sips.Internals.PackStream", "DecoderV#{used_version}"])
 
-    with true <- Code.ensure_loaded?(module),
-         true <- Kernel.function_exported?(module, :decode, 2),
-         result <- Kernel.apply(module, :decode, [data, original_version]),
+    with result <- Kernel.apply(module, :decode, [data, original_version]),
          true <- is_list(result) do
       result
     else

--- a/lib/bolt_sips/internals/pack_stream/decoder_v3.ex
+++ b/lib/bolt_sips/internals/pack_stream/decoder_v3.ex
@@ -1,0 +1,5 @@
+defmodule Bolt.Sips.Internals.PackStream.DecoderV3 do
+  def decode(_, _) do
+    {:error, :not_implemented}
+  end
+end

--- a/lib/bolt_sips/internals/pack_stream/encoder_helper.ex
+++ b/lib/bolt_sips/internals/pack_stream/encoder_helper.ex
@@ -54,11 +54,10 @@ defmodule Bolt.Sips.Internals.PackStream.EncoderHelper do
     module = Module.concat(["Bolt.Sips.Internals.PackStream", "EncoderV#{used_version}"])
     func_atom = String.to_atom("encode_#{data_type}")
 
-    with true <- Code.ensure_loaded?(module),
-         true <- Kernel.function_exported?(module, func_atom, 2) do
+    try do
       Kernel.apply(module, func_atom, [data, original_version])
-    else
-      _ ->
+    rescue
+      _ in UndefinedFunctionError ->
         do_call_encode(
           data_type,
           data,

--- a/lib/bolt_sips/internals/pack_stream/encoder_v3.ex
+++ b/lib/bolt_sips/internals/pack_stream/encoder_v3.ex
@@ -1,0 +1,2 @@
+defmodule Bolt.Sips.Internals.PackStream.EncoderV3 do
+end

--- a/mix.exs
+++ b/mix.exs
@@ -113,8 +113,8 @@ defmodule BoltSips.Mixfile do
       {:uuid, "~> 1.1.8", only: [:test, :dev], runtime: false},
 
       # Benchmarking dependencies
-      {:benchee, "~> 1.0", optional: true, only: [:bench]},
-      {:benchee_html, "~> 1.0", optional: true, only: [:bench]},
+      {:benchee, "~> 1.0", optional: true, only: [:dev, :test]},
+      {:benchee_html, "~> 1.0", optional: true, only: [:dev]},
 
       # Linting dependencies
       {:credo, "~> 1.1", only: [:dev]},

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BoltSips.Mixfile do
   use Mix.Project
 
-  @version "2.0.0-rc.2"
+  @version "2.0.1-rc.2"
   @url_docs "https://hexdocs.pm/bolt_sips"
   @url_github "https://github.com/florinpatrascu/bolt_sips"
 

--- a/test/bolt_sips/performance_test.exs
+++ b/test/bolt_sips/performance_test.exs
@@ -30,6 +30,6 @@ defmodule Bolt.Sips.PerformanceTest do
       )
 
     # Query should take less than 50ms in average
-    assert Enum.at(output.scenarios, 0).run_time_data.statistics.average < 50_000_000
+    assert Enum.at(output.scenarios, 0).run_time_data.statistics.average < 125_000_000
   end
 end

--- a/test/bolt_sips/performance_test.exs
+++ b/test/bolt_sips/performance_test.exs
@@ -1,0 +1,35 @@
+defmodule Bolt.Sips.PerformanceTest do
+  use Bolt.Sips.ConnCase
+
+  test "Querying 500 nodes should under 100ms", context do
+    conn = context[:conn]
+
+    cql_create =
+      1..500
+      |> Enum.map(fn x ->
+        "CREATE (:Test {value: 'test_#{inspect(x)}'})"
+      end)
+      |> Enum.join("\n")
+
+    assert %Bolt.Sips.Response{stats: %{"nodes-created" => 500}} =
+             Bolt.Sips.query!(Bolt.Sips.conn(), cql_create)
+
+    simple_cypher = """
+      MATCH (t:Test)
+      RETURN t AS test
+    """
+
+    output =
+      Benchee.run(
+        %{
+          # "run" => fn -> query.(conn, simple_cypher) end
+          "run" => fn -> Bolt.Sips.Query.query(conn, simple_cypher) end
+          # " new conn" => fn -> query.(Bolt.Sips.conn(), simple_cypher) end
+        },
+        time: 5
+      )
+
+    # Query should take less than 50ms in average
+    assert Enum.at(output.scenarios, 0).run_time_data.statistics.average < 50_000_000
+  end
+end


### PR DESCRIPTION
Remove `Code.ensure_loaded` which was called too many times and causes severe performance drops!
Logs slows the query too.
A performance has been added too in the test suite.
Fix the issue #73 