### PR TITLE
feat: support connection options in queries

### DIFF
--- a/lib/bolt_sips.ex
+++ b/lib/bolt_sips.ex
@@ -159,6 +159,20 @@ defmodule Bolt.Sips do
   @spec query!(conn, String.t(), map()) :: Response.t() | [Response.t()] | Exception.t()
   defdelegate query!(conn, statement, params), to: Query
 
+  @doc """
+  send a query and an associated map of parameters with options. Returns the server response or an error
+  """
+  @spec query(conn, String.t(), map(), Keyword.t()) ::
+          {:ok, Response.t() | [Response.t()]} | {:error, Error.t()}
+  defdelegate query(conn, statement, params, opts), to: Query
+
+  @doc """
+  The same as query/4 but raises a Exception if it fails.
+  """
+  @spec query!(conn, String.t(), map(), Keyword.t()) ::
+          Response.t() | [Response.t()] | Exception.t()
+  defdelegate query!(conn, statement, params, opts), to: Query
+
   ## Transaction
   ########################
 


### PR DESCRIPTION
I needed to support a longer timeout than the default (15 seconds) for a bulk query... this pull request adds support for passing options through to `DBConnection.execute/4`.