### PR TITLE
Fix warnings and typespec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.6
+- Fix 'unused alias' compilation warnings  
+- Fix Bolt.Sips.Response type: `stats` was a `list` instead of `list|map`  
+- Add typespec for Bolt.Sips.Types: Node, Relationship and UnboundRelationship  
+
 ## 2.0.5
 
 - fix #83. More details in commit: https://github.com/florinpatrascu/bolt_sips/commit/ebe17e62ab1d823e301b11d99d532663b0b25135 Thank you @kristofka!

--- a/lib/bolt_sips/internals/pack_stream/decoder_impl_v1.ex
+++ b/lib/bolt_sips/internals/pack_stream/decoder_impl_v1.ex
@@ -1,8 +1,5 @@
 defmodule Bolt.Sips.Internals.PackStream.DecoderImplV1 do
-  alias Bolt.Sips.Internals.BoltVersionHelper
-  alias Bolt.Sips.Internals.PackStreamError
   alias Bolt.Sips.Types
-  alias Bolt.Sips.Types.{TimeWithTZOffset, DateTimeWithTZOffset, Duration, Point}
 
   defmacro __using__(_options) do
     quote do

--- a/lib/bolt_sips/internals/pack_stream/v2.ex
+++ b/lib/bolt_sips/internals/pack_stream/v2.ex
@@ -1,7 +1,6 @@
 defmodule Bolt.Sips.Internals.PackStream.V2 do
   alias Bolt.Sips.Types.{TimeWithTZOffset, DateTimeWithTZOffset, Duration, Point}
   alias Bolt.Sips.Internals.PackStream.Encoder
-  alias Bolt.Sips.Internals.PackStreamError
 
   defmacro __using__(_options) do
     quote do

--- a/lib/bolt_sips/response.ex
+++ b/lib/bolt_sips/response.ex
@@ -63,7 +63,7 @@ defmodule Bolt.Sips.Response do
           records: list,
           plan: map,
           notifications: list,
-          stats: list,
+          stats: list | map,
           profile: any,
           type: String.t(),
           bookmark: String.t()

--- a/lib/bolt_sips/types.ex
+++ b/lib/bolt_sips/types.ex
@@ -57,6 +57,12 @@ defmodule Bolt.Sips.Types do
     """
 
     use Entity, labels: nil
+
+    @type t :: %__MODULE__{
+            id: integer,
+            labels: [String.t()],
+            properties: map
+          }
   end
 
   defmodule Relationship do
@@ -71,6 +77,11 @@ defmodule Bolt.Sips.Types do
     """
 
     use Entity, start: nil, end: nil, type: nil
+
+    @type t :: %__MODULE__{
+            id: integer,
+            properties: map
+          }
   end
 
   defmodule UnboundRelationship do
@@ -83,6 +94,11 @@ defmodule Bolt.Sips.Types do
     """
 
     use Entity, start: nil, end: nil, type: nil
+
+    @type t :: %__MODULE__{
+            id: integer,
+            properties: map
+          }
   end
 
   defmodule Path do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BoltSips.Mixfile do
   use Mix.Project
 
-  @version "2.0.5"
+  @version "2.0.6"
   @url_docs "https://hexdocs.pm/bolt_sips"
   @url_github "https://github.com/florinpatrascu/bolt_sips"
 


### PR DESCRIPTION
A quick PR for:
- fixing 'unused alias' warnings
- Fix Bolt.Sips.Response type which fails for `stats`
- Add typespec for Node, Relationship which can (will) be useful for projects using bolt_sips