### PR TITLE
Fix case where the version is without a patch: e.g. "Neo4j/3.5"

### DIFF
--- a/lib/bolt_sips/router.ex
+++ b/lib/bolt_sips/router.ex
@@ -329,10 +329,16 @@ defmodule Bolt.Sips.Router do
   end
 
   defp parse_server_version(%{"server" => server_version_string}) do
-    %{"M" => major, "m" => minor, "p" => patch} =
-      Regex.named_captures(~r/Neo4j\/(?<M>\d+)\.(?<m>\d+)\.(?<p>\d+)/, server_version_string)
+    ["Neo4j", version] = String.split(server_version_string, "/")
 
-    {server_version_string, "#{major}.#{minor}.#{patch}"}
+    {server_version_string,
+     case String.split(version, ".") do
+       [major, minor] ->
+         "#{major}.#{minor}.0"
+
+       [major, minor, patch] ->
+         "#{major}.#{minor}.#{patch}"
+     end}
   end
 
   defp parse_server_version(some_version),


### PR DESCRIPTION
I ran into an error trying to connect to an Aura Neo4j database together with Routing. The server version is returned as "Neo4j/3.5". The existing regex expression doesn't allow for that and the connection crashes.

Using Neo4j Browser the db version is the same (without a patch) 
"Neo4j Kernel" | "3.5" | "enterprise"

I've amended the code so that when it appears without a patch, it will return with patch of `0`. i.e. "Neo4j/3.5" will return `{"Neo4j/3.5", "3.5.0"}` when `parse_server_version` is called. Otherwise patch versions will be included like normal
