### PR TITLE
simple change: {param} -> $param 

### DIFF
--- a/lib/bolt_sips/router.ex
+++ b/lib/bolt_sips/router.ex
@@ -200,7 +200,7 @@ defmodule Bolt.Sips.Router do
       {query, params} =
         if Version.match?(short, ">= 3.2.3") do
           props = Keyword.get(opts, :routing_context, %{})
-          {"CALL dbms.cluster.routing.getRoutingTable({context})", %{context: props}}
+          {"CALL dbms.cluster.routing.getRoutingTable($context)", %{context: props}}
         else
           {"CALL dbms.cluster.routing.getServers()", %{}}
         end


### PR DESCRIPTION
now allows CC routing to work in Neo4j 4.x

haven't tested backward compatibility with Neo4j 3.x. I suspect its a breaking change.