### PR TITLE
Bug fix microsecond in time and datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.8
+
+- Fix Response.profile not being properly filled. Closes #91 
+
 ## 2.0.7
 
 - sometimes the server version is missing the patch number, and the router couldn't return the proper version. Thank you @barry-w-hill, for finding this bug and reporting it!

--- a/lib/bolt_sips/internals/pack_stream/decoder_impl_v2.ex
+++ b/lib/bolt_sips/internals/pack_stream/decoder_impl_v2.ex
@@ -106,7 +106,7 @@ defmodule Bolt.Sips.Internals.PackStream.DecoderImplV2 do
           when bolt_version >= 2 and bolt_version <= @last_version do
         {[time], rest} = decode_struct(struct, @local_time_struct_size, bolt_version)
 
-        [Time.add(~T[00:00:00.000], time, :nanosecond) | rest]
+        [Time.add(~T[00:00:00.000000], time, :nanosecond) | rest]
       end
 
       # Local DateTime
@@ -117,7 +117,7 @@ defmodule Bolt.Sips.Internals.PackStream.DecoderImplV2 do
 
         ndt =
           NaiveDateTime.add(
-            ~N[1970-01-01 00:00:00.000],
+            ~N[1970-01-01 00:00:00.000000000],
             seconds * 1_000_000_000 + nanoseconds,
             :nanosecond
           )
@@ -130,7 +130,7 @@ defmodule Bolt.Sips.Internals.PackStream.DecoderImplV2 do
           when bolt_version >= 2 and bolt_version <= @last_version do
         {[time, offset], rest} = decode_struct(struct, @time_with_tz_struct_size, bolt_version)
 
-        t = TimeWithTZOffset.create(Time.add(~T[00:00:00.000], time, :nanosecond), offset)
+        t = TimeWithTZOffset.create(Time.add(~T[00:00:00.000000], time, :nanosecond), offset)
         [t | rest]
       end
 
@@ -145,7 +145,7 @@ defmodule Bolt.Sips.Internals.PackStream.DecoderImplV2 do
 
         naive_dt =
           NaiveDateTime.add(
-            ~N[1970-01-01 00:00:00.000],
+            ~N[1970-01-01 00:00:00.000000],
             seconds * 1_000_000_000 + nanoseconds,
             :nanosecond
           )
@@ -166,7 +166,7 @@ defmodule Bolt.Sips.Internals.PackStream.DecoderImplV2 do
 
         naive_dt =
           NaiveDateTime.add(
-            ~N[1970-01-01 00:00:00.000],
+            ~N[1970-01-01 00:00:00.000000],
             seconds * 1_000_000_000 + nanoseconds,
             :nanosecond
           )

--- a/lib/bolt_sips/response.ex
+++ b/lib/bolt_sips/response.ex
@@ -159,8 +159,8 @@ defmodule Bolt.Sips.Response do
     %{response | fields: fields}
   end
 
-  defp parse_record(:success, %{"profile" => profile, "stats" => stats, "type" => type}, response) do
-    %{response | profile: profile, stats: stats, type: type}
+  defp parse_record(:success, %{"profile" => profile, "type" => type} = record, response) do
+    %{response | profile: profile, stats: Map.get(record, "stats", []), type: type}
   end
 
   defp parse_record(:success, %{"notifications" => n, "plan" => plan, "type" => type}, response) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BoltSips.Mixfile do
   use Mix.Project
 
-  @version "2.0.7"
+  @version "2.0.8"
   @url_docs "https://hexdocs.pm/bolt_sips"
   @url_github "https://github.com/florinpatrascu/bolt_sips"
 

--- a/test/query_bolt_v2_test.exs
+++ b/test/query_bolt_v2_test.exs
@@ -77,7 +77,7 @@ defmodule Bolt.Sips.QueryBoltV2Test do
   test "transform TimeWithTZOffset in cypher-compliant data", context do
     conn = context[:conn]
     query = "RETURN time({t}) AS t"
-    time_with_tz = %TimeWithTZOffset{time: ~T[12:45:30.250000], timezone_offset: 3600}
+    time_with_tz = %TimeWithTZOffset{time: ~T[12:45:30.250876], timezone_offset: 3600}
     params = %{t: time_with_tz}
 
     assert {:ok, %Response{results: [%{"t" => ^time_with_tz}]}} =
@@ -89,7 +89,7 @@ defmodule Bolt.Sips.QueryBoltV2Test do
     query = "RETURN datetime({t}) AS t"
 
     date_time_with_tz = %DateTimeWithTZOffset{
-      naive_datetime: ~N[2016-05-24 13:26:08.543],
+      naive_datetime: ~N[2016-05-24 13:26:08.543267],
       timezone_offset: 7200
     }
 
@@ -103,7 +103,8 @@ defmodule Bolt.Sips.QueryBoltV2Test do
     conn = context[:conn]
     query = "RETURN datetime({t}) AS t"
 
-    date_time_with_tz_id = TypesHelper.datetime_with_micro(~N[2016-05-24 13:26:08.543], "Etc/UTC")
+    date_time_with_tz_id =
+      TypesHelper.datetime_with_micro(~N[2016-05-24 13:26:08.543218], "Etc/UTC")
 
     params = %{t: date_time_with_tz_id}
 
@@ -116,7 +117,7 @@ defmodule Bolt.Sips.QueryBoltV2Test do
     query = "RETURN datetime({t}) AS t"
 
     date_time_with_tz_id =
-      TypesHelper.datetime_with_micro(~N[2016-05-24 13:26:08.543], "Europe/Paris")
+      TypesHelper.datetime_with_micro(~N[2016-05-24 13:26:08.543789], "Europe/Paris")
 
     params = %{t: date_time_with_tz_id}
 
@@ -128,7 +129,7 @@ defmodule Bolt.Sips.QueryBoltV2Test do
     conn = context[:conn]
     query = "RETURN localdatetime({t}) AS t"
 
-    ndt = ~N[2016-05-24 13:26:08.543]
+    ndt = ~N[2016-05-24 13:26:08.543156]
     params = %{t: ndt}
 
     assert {:ok, %Response{results: [%{"t" => ^ndt}]}} = Bolt.Sips.query(conn, query, params)

--- a/test/response_test.exs
+++ b/test/response_test.exs
@@ -88,34 +88,137 @@ defmodule ResponseTest do
     }
   ]
 
-  @profile [
-    success: %{"fields" => ["n"], "t_first" => 1},
+  @profile_no_results [
+    success: %{"fields" => [], "t_first" => 20},
     success: %{
-      "bookmark" => "neo4j:bookmark:v1:tx13440",
-      "plan" => %{
+      "bookmark" => "neo4j:bookmark:v1:tx48642",
+      "profile" => %{
         "args" => %{
+          "DbHits" => 0,
           "EstimatedRows" => 1.0,
+          "PageCacheHitRatio" => 0.0,
+          "PageCacheHits" => 0,
+          "PageCacheMisses" => 0,
+          "Rows" => 0,
           "planner" => "COST",
           "planner-impl" => "IDP",
           "planner-version" => "3.5",
-          "runtime" => "INTERPRETED",
-          "runtime-impl" => "INTERPRETED",
+          "runtime" => "SLOTTED",
+          "runtime-impl" => "SLOTTED",
           "runtime-version" => "3.5",
           "version" => "CYPHER 3.5"
         },
         "children" => [
           %{
-            "args" => %{"EstimatedRows" => 1.0},
-            "children" => [],
+            "args" => %{
+              "DbHits" => 0,
+              "EstimatedRows" => 1.0,
+              "PageCacheHitRatio" => 0.0,
+              "PageCacheHits" => 0,
+              "PageCacheMisses" => 0,
+              "Rows" => 0
+            },
+            "children" => [
+              %{
+                "args" => %{
+                  "DbHits" => 3,
+                  "EstimatedRows" => 1.0,
+                  "PageCacheHitRatio" => 0.0,
+                  "PageCacheHits" => 0,
+                  "PageCacheMisses" => 0,
+                  "Rows" => 1
+                },
+                "children" => [],
+                "dbHits" => 3,
+                "identifiers" => ["n"],
+                "operatorType" => "Create",
+                "pageCacheHitRatio" => 0.0,
+                "pageCacheHits" => 0,
+                "pageCacheMisses" => 0,
+                "rows" => 1
+              }
+            ],
+            "dbHits" => 0,
             "identifiers" => ["n"],
-            "operatorType" => "Create"
+            "operatorType" => "EmptyResult",
+            "pageCacheHitRatio" => 0.0,
+            "pageCacheHits" => 0,
+            "pageCacheMisses" => 0,
+            "rows" => 0
           }
         ],
+        "dbHits" => 0,
         "identifiers" => ["n"],
-        "operatorType" => "ProduceResults"
+        "operatorType" => "ProduceResults",
+        "pageCacheHitRatio" => 0.0,
+        "pageCacheHits" => 0,
+        "pageCacheMisses" => 0,
+        "rows" => 0
+      },
+      "stats" => %{
+        "labels-added" => 1,
+        "nodes-created" => 1,
+        "properties-set" => 1
       },
       "t_last" => 0,
-      "type" => "rw"
+      "type" => "w"
+    }
+  ]
+
+  @profile_results [
+    success: %{"fields" => ["num"], "t_first" => 1},
+    record: [1],
+    success: %{
+      "bookmark" => "neo4j:bookmark:v1:tx48642",
+      "profile" => %{
+        "args" => %{
+          "DbHits" => 0,
+          "EstimatedRows" => 1.0,
+          "PageCacheHitRatio" => 0.0,
+          "PageCacheHits" => 0,
+          "PageCacheMisses" => 0,
+          "Rows" => 1,
+          "Time" => 25980,
+          "planner" => "COST",
+          "planner-impl" => "IDP",
+          "planner-version" => "3.5",
+          "runtime" => "COMPILED",
+          "runtime-impl" => "COMPILED",
+          "runtime-version" => "3.5",
+          "version" => "CYPHER 3.5"
+        },
+        "children" => [
+          %{
+            "args" => %{
+              "DbHits" => 0,
+              "EstimatedRows" => 1.0,
+              "Expressions" => "{num : $`  AUTOINT0`}",
+              "PageCacheHitRatio" => 0.0,
+              "PageCacheHits" => 0,
+              "PageCacheMisses" => 0,
+              "Rows" => 1,
+              "Time" => 42285
+            },
+            "children" => [],
+            "dbHits" => 0,
+            "identifiers" => ["num"],
+            "operatorType" => "Projection",
+            "pageCacheHitRatio" => 0.0,
+            "pageCacheHits" => 0,
+            "pageCacheMisses" => 0,
+            "rows" => 1
+          }
+        ],
+        "dbHits" => 0,
+        "identifiers" => ["num"],
+        "operatorType" => "ProduceResults",
+        "pageCacheHitRatio" => 0.0,
+        "pageCacheHits" => 0,
+        "pageCacheMisses" => 0,
+        "rows" => 1
+      },
+      "t_last" => 0,
+      "type" => "r"
     }
   ]
 
@@ -206,31 +309,134 @@ defmodule ResponseTest do
              } = notifications
     end
 
-    test "with Profile" do
-      %Response{plan: plan} = Response.transform!(@profile)
+    test "with Profile (without results)" do
+      %Response{plan: nil, profile: profile, stats: stats} =
+        Response.transform!(@profile_no_results)
 
       assert %{
                "args" => %{
+                 "DbHits" => 0,
                  "EstimatedRows" => 1.0,
+                 "PageCacheHitRatio" => 0.0,
+                 "PageCacheHits" => 0,
+                 "PageCacheMisses" => 0,
+                 "Rows" => 0,
                  "planner" => "COST",
                  "planner-impl" => "IDP",
                  "planner-version" => "3.5",
-                 "runtime" => "INTERPRETED",
-                 "runtime-impl" => "INTERPRETED",
+                 "runtime" => "SLOTTED",
+                 "runtime-impl" => "SLOTTED",
                  "runtime-version" => "3.5",
                  "version" => "CYPHER 3.5"
                },
                "children" => [
                  %{
-                   "args" => %{"EstimatedRows" => 1.0},
-                   "children" => [],
+                   "args" => %{
+                     "DbHits" => 0,
+                     "EstimatedRows" => 1.0,
+                     "PageCacheHitRatio" => 0.0,
+                     "PageCacheHits" => 0,
+                     "PageCacheMisses" => 0,
+                     "Rows" => 0
+                   },
+                   "children" => [
+                     %{
+                       "args" => %{
+                         "DbHits" => 3,
+                         "EstimatedRows" => 1.0,
+                         "PageCacheHitRatio" => 0.0,
+                         "PageCacheHits" => 0,
+                         "PageCacheMisses" => 0,
+                         "Rows" => 1
+                       },
+                       "children" => [],
+                       "dbHits" => 3,
+                       "identifiers" => ["n"],
+                       "operatorType" => "Create",
+                       "pageCacheHitRatio" => 0.0,
+                       "pageCacheHits" => 0,
+                       "pageCacheMisses" => 0,
+                       "rows" => 1
+                     }
+                   ],
+                   "dbHits" => 0,
                    "identifiers" => ["n"],
-                   "operatorType" => "Create"
+                   "operatorType" => "EmptyResult",
+                   "pageCacheHitRatio" => 0.0,
+                   "pageCacheHits" => 0,
+                   "pageCacheMisses" => 0,
+                   "rows" => 0
                  }
                ],
+               "dbHits" => 0,
                "identifiers" => ["n"],
-               "operatorType" => "ProduceResults"
-             } = plan
+               "operatorType" => "ProduceResults",
+               "pageCacheHitRatio" => 0.0,
+               "pageCacheHits" => 0,
+               "pageCacheMisses" => 0,
+               "rows" => 0
+             } = profile
+
+      assert %{
+               "labels-added" => 1,
+               "nodes-created" => 1,
+               "properties-set" => 1
+             } = stats
+    end
+
+    test "with Profile (with results)" do
+      %Response{plan: nil, profile: profile, stats: [], records: records, results: results} =
+        Response.transform!(@profile_results)
+
+      assert %{
+               "args" => %{
+                 "DbHits" => 0,
+                 "EstimatedRows" => 1.0,
+                 "PageCacheHitRatio" => 0.0,
+                 "PageCacheHits" => 0,
+                 "PageCacheMisses" => 0,
+                 "Rows" => 1,
+                 "Time" => 25980,
+                 "planner" => "COST",
+                 "planner-impl" => "IDP",
+                 "planner-version" => "3.5",
+                 "runtime" => "COMPILED",
+                 "runtime-impl" => "COMPILED",
+                 "runtime-version" => "3.5",
+                 "version" => "CYPHER 3.5"
+               },
+               "children" => [
+                 %{
+                   "args" => %{
+                     "DbHits" => 0,
+                     "EstimatedRows" => 1.0,
+                     "Expressions" => "{num : $`  AUTOINT0`}",
+                     "PageCacheHitRatio" => 0.0,
+                     "PageCacheHits" => 0,
+                     "PageCacheMisses" => 0,
+                     "Rows" => 1,
+                     "Time" => 42285
+                   },
+                   "children" => [],
+                   "dbHits" => 0,
+                   "identifiers" => ["num"],
+                   "operatorType" => "Projection",
+                   "pageCacheHitRatio" => 0.0,
+                   "pageCacheHits" => 0,
+                   "pageCacheMisses" => 0,
+                   "rows" => 1
+                 }
+               ],
+               "dbHits" => 0,
+               "identifiers" => ["num"],
+               "operatorType" => "ProduceResults",
+               "pageCacheHitRatio" => 0.0,
+               "pageCacheHits" => 0,
+               "pageCacheMisses" => 0,
+               "rows" => 1
+             } = profile
+
+      assert [%{"num" => 1}] = results
     end
   end
 end


### PR DESCRIPTION
Except in time, temporal types was only using milliseconds  where microseconds are available.
Now microseconds are available on any temporal type