### PR TITLE
Add configurable SSL options

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -17,6 +17,7 @@ These are the values you can configure, and their default values:
 - `:pool_size` - the size of the connection pool. Default: 15
 - `:timeout` - a connection timeout value defined in milliseconds. Default: 15_000
 - `:ssl`-`true`, if the connection must be encrypted. Default:`false`
+- `:ssl_options` - if the user wants to specify custom ssl options. More info [here](https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl). Default: `[]` 
 - `:prefix`- used for differentiating between multiple connections available in the same app. Default:`:default`
 
 ## Examples of configurations

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -16,8 +16,7 @@ These are the values you can configure, and their default values:
 - `:url`- a full url to pointing to a running Neo4j server. Please remember you must specify the scheme used to connect to the server. Valid schemes:`bolt`,`bolt+routing`and`neo4j` - the last two being used for connecting to a Neo4j causal cluster.
 - `:pool_size` - the size of the connection pool. Default: 15
 - `:timeout` - a connection timeout value defined in milliseconds. Default: 15_000
-- `:ssl`-`true`, if the connection must be encrypted. Default:`false`
-- `:ssl_options` - if the user wants to specify custom ssl options. More info [here](https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl). Default: `[]` 
+- `:ssl`-`true`, if the connection must be encrypted. If the user wants to specify custom ssl options, just pass a keyword list with the options. More info [here](https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl) Default:`false`
 - `:prefix`- used for differentiating between multiple connections available in the same app. Default:`:default`
 
 ## Examples of configurations
@@ -28,9 +27,8 @@ Connecting to remote (hosted) Neo4j servers, such as the ones available (also fo
 config :bolt_sips, Bolt,
   url: "bolt://<ip_address>:<bolt_port>",
   basic_auth: [username: "neo4j", password: "#######"]
-  ssl: true
+  ssl: true # or for example `[verify: :verify_none]` if custom ssl options
 ```
-
 
 ## Direct mode
 

--- a/lib/bolt_sips/protocol.ex
+++ b/lib/bolt_sips/protocol.ex
@@ -35,7 +35,13 @@ defmodule Bolt.Sips.Protocol do
     auth = extract_auth(conf[:basic_auth])
     timeout = conf[:timeout]
     socket = conf[:socket]
-    socket_opts = [packet: :raw, mode: :binary, active: false]
+    default_socket_options = [packet: :raw, mode: :binary, active: false]
+
+    socket_opts =
+      case conf[:ssl] do
+        true -> Keyword.merge(default_socket_options, conf[:ssl_options])
+        _ -> default_socket_options
+      end
 
     with {:ok, sock} <- socket.connect(host, port, socket_opts, timeout),
          {:ok, bolt_version} <- BoltProtocol.handshake(socket, sock),

--- a/lib/bolt_sips/protocol.ex
+++ b/lib/bolt_sips/protocol.ex
@@ -39,7 +39,7 @@ defmodule Bolt.Sips.Protocol do
 
     socket_opts =
       case conf[:ssl] do
-        true -> Keyword.merge(default_socket_options, conf[:ssl_options])
+        list when is_list(list) -> Keyword.merge(default_socket_options, conf[:ssl])
         _ -> default_socket_options
       end
 

--- a/lib/bolt_sips/router.ex
+++ b/lib/bolt_sips/router.ex
@@ -151,7 +151,7 @@ defmodule Bolt.Sips.Router do
     ssl_or_sock = if(Keyword.get(options, :ssl), do: :ssl, else: Keyword.get(options, :socket))
 
     user_options = Keyword.put(options, :socket, ssl_or_sock)
-    with_routing? = Keyword.get(user_options, :schema, "bolt") =~ ~r/(^neo4j$)|(^bolt\+routing$)/i
+    with_routing? = Keyword.get(user_options, :schema, "bolt") =~ ~r/(^bolt\+routing$)/i
 
     with {:ok, routing_table} <- get_routing_table(user_options, with_routing?),
          {:ok, connections} <- start_connections(user_options, routing_table) do

--- a/lib/bolt_sips/utils.ex
+++ b/lib/bolt_sips/utils.ex
@@ -12,7 +12,6 @@ defmodule Bolt.Sips.Utils do
     max_overflow: 0,
     timeout: 15_000,
     ssl: false,
-    ssl_options: [],
     socket: Bolt.Sips.Socket,
     with_etls: false,
     schema: "bolt",
@@ -44,7 +43,6 @@ defmodule Bolt.Sips.Utils do
     |> Keyword.put_new(:max_overflow, 2)
     |> Keyword.put_new(:timeout, 15_000)
     |> Keyword.put_new(:ssl, false)
-    |> Keyword.put_new(:ssl_options, [])
     |> Keyword.put_new(:socket, Bolt.Sips.Socket)
     |> Keyword.put_new(:with_etls, false)
     |> Keyword.put_new(:schema, "bolt")

--- a/lib/bolt_sips/utils.ex
+++ b/lib/bolt_sips/utils.ex
@@ -12,6 +12,7 @@ defmodule Bolt.Sips.Utils do
     max_overflow: 0,
     timeout: 15_000,
     ssl: false,
+    ssl_options: [],
     socket: Bolt.Sips.Socket,
     with_etls: false,
     schema: "bolt",
@@ -43,6 +44,7 @@ defmodule Bolt.Sips.Utils do
     |> Keyword.put_new(:max_overflow, 2)
     |> Keyword.put_new(:timeout, 15_000)
     |> Keyword.put_new(:ssl, false)
+    |> Keyword.put_new(:ssl_options, [])
     |> Keyword.put_new(:socket, Bolt.Sips.Socket)
     |> Keyword.put_new(:with_etls, false)
     |> Keyword.put_new(:schema, "bolt")

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -9,7 +9,8 @@ defmodule Config.Test do
   @basic_tls_config [
     url: @graphenedb_like_url,
     basic_auth: [username: "xmas", password: "Kr1ngl3"],
-    ssl: true
+    ssl: true,
+    ssl_options: [verify: :verify_none]
   ]
 
   @light_tls_config [
@@ -40,6 +41,7 @@ defmodule Config.Test do
     assert config[:basic_auth] == [username: "xmas", password: "Kr1ngl3"]
     assert config[:port] == 24786
     assert config[:ssl] == true
+    assert config[:ssl_options] == [verify: :verify_none]
     assert config[:prefix] == :default
   end
 
@@ -69,6 +71,7 @@ defmodule Config.Test do
     assert config[:basic_auth] == [username: "xmas", password: "Kr1ngl3"]
     assert config[:port] == 24786
     assert config[:ssl] == true
+    assert config[:ssl_options] == []
   end
 
   test "standard Bolt.Sips default configuration" do

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -9,8 +9,7 @@ defmodule Config.Test do
   @basic_tls_config [
     url: @graphenedb_like_url,
     basic_auth: [username: "xmas", password: "Kr1ngl3"],
-    ssl: true,
-    ssl_options: [verify: :verify_none]
+    ssl: [verify: :verify_none]
   ]
 
   @light_tls_config [
@@ -40,8 +39,7 @@ defmodule Config.Test do
     assert config[:hostname] == "hobby-happyHoHoHo.dbs.graphenedb.com"
     assert config[:basic_auth] == [username: "xmas", password: "Kr1ngl3"]
     assert config[:port] == 24786
-    assert config[:ssl] == true
-    assert config[:ssl_options] == [verify: :verify_none]
+    assert config[:ssl] == [verify: :verify_none]
     assert config[:prefix] == :default
   end
 


### PR DESCRIPTION
Why:
 - Add the possibility of configuring SSL options if the user chooses to. 
 
How:
 - Check if the connection type is `:ssl` (by specifying `true` to keep retro-compatibility or by specifying a keyword list). 
 - If a list is passed, it merges the default options with the ones given by the user.
 - If no options are passed or the connection is not `:ssl` the default list is used.