### PR TITLE
Query.Utils with a function to have cypher prepared statements

### DIFF
--- a/docs/features/using-cypher.md
+++ b/docs/features/using-cypher.md
@@ -129,3 +129,22 @@ iex» response |>
 ```
 
 and much more. Check the `Bolt.Sips.Response`'s own docs, for more.
+
+## Protection against Cypher Injection
+
+If you want to secure your queries against Cypher Injection where Neo4j parameters don't work
+you can use `Bolt.Sips.Query.Utils.prepared_statement/2` to escape the variables you want to use
+in as Label or Relationship names. Check [more information here](https://neo4j.com/developer/kb/protecting-against-cypher-injection/)
+
+Example:
+
+```elixir
+label = "Robby' WITH DISTINCT true as haxxored MATCH (s:Student) DETACH DELETE s //"
+query = 
+  "CREATE (s:{{label}}) SET s.name = 'student name'"
+  |> Bolt.Sips.Query.prepared_statement([label: label])
+
+Bolt.Sips.query!(conn, query)
+```
+
+

--- a/lib/bolt_sips/query/utils.ex
+++ b/lib/bolt_sips/query/utils.ex
@@ -1,0 +1,33 @@
+defmodule Bolt.Sips.Query.Utils do
+  @moduledoc """
+  Util functions to be used together with `Bolt.Sips.Query`.
+  """
+
+  @doc """
+  `prepared_statement/2` should be used when parameters are not possible to use, for example
+  in this situation: https://neo4j.com/developer/kb/protecting-against-cypher-injection/#_when_you_must_append_into_a_query_string_sanitize_your_inputs
+
+  If we want to have label or relationship names being passed as variables, we can't use Neo4j parameters, so we'd be susceptible to label injection.
+  This function escapes `'` characters from the values passed and replaces them in the query string.
+
+  The code bellow would return a safe query string that we can use with `Bolt.Sips.Query` later.
+
+  iex>"CREATE (s:{{label}}) SET s.name = 'Some Name'"
+  ...>  |> Bolt.Sips.Query.Utils.prepared_statement([label: "Something' Bad"])
+  ```
+  """
+  @spec prepared_statement(String.t(), keyword({atom(), String.t()})) :: String.t()
+  def prepared_statement(query_string, variables \\ []) when is_list(variables) do
+    prepared_vars =
+      Enum.map(variables, fn {key, value} ->
+        case value do
+          nil -> {key, ""}
+          _ -> {key, String.replace(value, "'", "\\'")}
+        end
+      end)
+
+    Enum.reduce(prepared_vars, query_string, fn {key, var}, acc ->
+      String.replace(acc, "{{#{key}}}", var)
+    end)
+  end
+end

--- a/test/query/utils_test.exs
+++ b/test/query/utils_test.exs
@@ -1,0 +1,30 @@
+defmodule Bolt.Sips.Query.UtilsTest do
+  use ExUnit.Case
+  doctest Bolt.Sips.Query.Utils
+
+  alias Bolt.Sips.Query
+
+  describe "prepared_statement/2" do
+    test "it creates a valid prepared statement, replacing the variables in place." do
+      query = "MATCH ({{label}}) -[{{relation}}] -> () DELETE {{label}}, {{relation}}"
+      parameters = [label: "Address", relation: "Sent"]
+
+      prepared_query = Query.Utils.prepared_statement(query, parameters)
+
+      assert prepared_query == "MATCH (Address) -[Sent] -> () DELETE Address, Sent"
+    end
+
+    test "it escapes parameters and returns a prepared statement" do
+      query = "CREATE (s:Student) SET s.name = '{{student_name}}'"
+
+      parameters = [
+        student_name: "Robby' WITH DISTINCT true as haxxored MATCH (s:Student) DETACH DELETE s //"
+      ]
+
+      prepared_query = Query.Utils.prepared_statement(query, parameters)
+
+      assert prepared_query ==
+               "CREATE (s:Student) SET s.name = 'Robby\\' WITH DISTINCT true as haxxored MATCH (s:Student) DETACH DELETE s //'"
+    end
+  end
+end


### PR DESCRIPTION
Why
 - As described in the Issue https://github.com/florinpatrascu/bolt_sips/issues/107 , there are some situations where it's not possible to use Neo4j parameters for fully safe usage of queries (more info [here](ttps://neo4j.com/developer/kb/protecting-against-cypher-injection/).

How:
- This PR introduces a new module called `Bolt.Sips.Query.Utils` that comes with a function to escape strings that could be used maliciously.
- Added documentation and examples.
- Added tests.